### PR TITLE
Fixed missing links

### DIFF
--- a/Arnor.cat
+++ b/Arnor.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2587-8b93-97a0-ad95" name="Arnor" book="Kingdoms of Men" revision="3" battleScribeVersion="2.00" authorName="Christian Sørup Jensen" authorContact="christiansorup@me.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2587-8b93-97a0-ad95" name="Arnor" book="Kingdoms of Men" revision="4" battleScribeVersion="2.00" authorName="Christian Sørup Jensen" authorContact="christiansorup@me.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules>
     <rule id="f184-b3da-e7aa-48fa" name="The Grey Company" book="Kingdoms of Men" page="36" hidden="false">
@@ -1040,12 +1040,6 @@ To represent this, the surviving twin&apos;s Strength is increased to 5 and his 
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="a511-f42a-7be7-2aa5" name="New InfoLink" hidden="false" targetId="4421-66c4-4f11-6776" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
         <infoLink id="46a0-eca1-c3a9-378d" name="New InfoLink" hidden="false" targetId="4176-6e26-b2c2-4d55" type="rule">
           <profiles/>
           <rules/>
@@ -1084,7 +1078,9 @@ To represent this, the surviving twin&apos;s Strength is increased to 5 and his 
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="c830-aacc-8dcf-c4eb" name="Shield" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -1111,7 +1107,9 @@ To represent this, the surviving twin&apos;s Strength is increased to 5 and his 
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups/>

--- a/Eregion_and_Rivendell.cat
+++ b/Eregion_and_Rivendell.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7e71-1951-deac-8195" name="Eregion and Rivendell" book="The Free Peoples" revision="2" battleScribeVersion="2.00" authorName="Christian Sørup Jensen" authorContact="christiansorup@me.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7e71-1951-deac-8195" name="Eregion and Rivendell" book="The Free Peoples" revision="3" battleScribeVersion="2.00" authorName="Christian Sørup Jensen" authorContact="christiansorup@me.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -212,7 +212,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="65c9-fdca-4d14-5b76" name="New InfoLink" hidden="false" targetId="0b1d-2177-4275-126d" type="profile">
+        <infoLink id="65c9-fdca-4d14-5b76" name="New InfoLink" hidden="false" targetId="21b8-8e9e-6161-0812" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -375,7 +375,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="b99f-1147-ffad-4ae4" name="New InfoLink" hidden="false" targetId="9b10-514e-8b67-ec9c" type="profile">
+            <infoLink id="b99f-1147-ffad-4ae4" name="New InfoLink" hidden="false" targetId="ac25-2fd8-3d85-7866" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1510,12 +1510,6 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="5a64-be1b-a8a7-3f6d" name="New InfoLink" hidden="false" targetId="4421-66c4-4f11-6776" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
       </infoLinks>
       <modifiers/>
       <constraints>
@@ -1532,14 +1526,7 @@
     <selectionEntry id="1319-c4f1-5cee-d812" name="Armour" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
-      <infoLinks>
-        <infoLink id="da54-9ea3-6384-c0e9" name="New InfoLink" hidden="false" targetId="be51-9605-904b-412c" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
+      <infoLinks/>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e0a-bc85-f7a3-e62b" type="min"/>
@@ -1555,14 +1542,7 @@
     <selectionEntry id="64d9-8937-c5ac-e151" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
-      <infoLinks>
-        <infoLink id="c343-285b-ee89-4b9b" name="New InfoLink" hidden="false" targetId="be51-9605-904b-412c" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
+      <infoLinks/>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="705d-4b6b-9db6-7055" type="min"/>

--- a/Lothlórien_and_Mirkwood.cat
+++ b/Lothlórien_and_Mirkwood.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ed42-db4f-9dc4-d679" name="Lothlórien and Mirkwood" revision="1" battleScribeVersion="2.00" authorName="Edward Horsman" authorContact="edhalto@gmail.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ed42-db4f-9dc4-d679" name="Lothlórien and Mirkwood" revision="2" battleScribeVersion="2.00" authorName="Edward Horsman" authorContact="edhalto@gmail.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -81,7 +81,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0193-2589-7211-fcdb" name="New InfoLink" hidden="false" targetId="0b1d-2177-4275-126d" type="profile">
+        <infoLink id="0193-2589-7211-fcdb" name="New InfoLink" hidden="false" targetId="21b8-8e9e-6161-0812" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -208,7 +208,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="694e-1532-35a1-8f20" name="New InfoLink" hidden="false" targetId="9b10-514e-8b67-ec9c" type="profile">
+            <infoLink id="694e-1532-35a1-8f20" name="New InfoLink" hidden="false" targetId="ac25-2fd8-3d85-7866" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -812,7 +812,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="6882-daca-043b-589c" name="New InfoLink" hidden="false" targetId="9998-89a4-9536-3a40" type="profile">
+            <infoLink id="6882-daca-043b-589c" name="New InfoLink" hidden="false" targetId="b55b-5615-4438-2b70" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1181,7 +1181,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="7132-f47c-1624-e7fc" name="New InfoLink" hidden="false" targetId="9998-89a4-9536-3a40" type="profile">
+            <infoLink id="842b-6dd5-2527-e81e" name="New InfoLink" hidden="false" targetId="b55b-5615-4438-2b70" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1807,7 +1807,9 @@
           <constraints/>
         </entryLink>
       </entryLinks>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="f2ac-ded9-17de-f7c2" name="Galadhrim Stormcaller" book="The Free Peoples" page="26" hidden="false" collective="false" categoryEntryId="8e06-cb8f-41c0-09a4" type="model">
       <profiles>
@@ -2194,7 +2196,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="d2c5-0ecc-0164-0df7" name="Pike" book="The Free Peoples" page="28" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -2215,7 +2219,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="ef00-2bc1-915a-10b7" name="Banner" book="The Free Peoples" page="28" hidden="false" collective="false" type="upgrade">
           <profiles/>

--- a/Minas_Tirith.cat
+++ b/Minas_Tirith.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2d85-84b6-487d-b636" name="Minas Tirith" book="Kingdoms of Men" revision="2" battleScribeVersion="2.00" authorName="Christian Sørup Jensen" authorContact="christiansorup@me.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2d85-84b6-487d-b636" name="Minas Tirith" book="Kingdoms of Men" revision="3" battleScribeVersion="2.00" authorName="Christian Sørup Jensen" authorContact="christiansorup@me.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -1373,7 +1373,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="224f-29df-d471-47a0" name="New InfoLink" hidden="false" targetId="9b10-514e-8b67-ec9c" type="profile">
+            <infoLink id="224f-29df-d471-47a0" name="New InfoLink" hidden="false" targetId="ac25-2fd8-3d85-7866" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1749,7 +1749,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="cd7b-f5db-7f08-a766" name="New InfoLink" hidden="false" targetId="9b10-514e-8b67-ec9c" type="profile">
+            <infoLink id="cd7b-f5db-7f08-a766" name="New InfoLink" hidden="false" targetId="ac25-2fd8-3d85-7866" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>

--- a/Númenor.cat
+++ b/Númenor.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9a55-4559-8cb7-9caa" name="Númenor" book="Kingdoms of Men" revision="2" battleScribeVersion="2.00" authorName="Christian Sørup Jensen" authorContact="christiansorup@me.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9a55-4559-8cb7-9caa" name="Númenor" book="Kingdoms of Men" revision="3" battleScribeVersion="2.00" authorName="Christian Sørup Jensen" authorContact="christiansorup@me.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -76,7 +76,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="370e-96d1-8a6a-e7f6" name="New InfoLink" hidden="false" targetId="9b10-514e-8b67-ec9c" type="profile">
+            <infoLink id="370e-96d1-8a6a-e7f6" name="New InfoLink" hidden="false" targetId="ac25-2fd8-3d85-7866" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>

--- a/Rohan.cat
+++ b/Rohan.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e167-5c41-57e7-502b" name="Rohan" book="Kingdoms of Men" revision="2" battleScribeVersion="2.00" authorName="Christian Sørup Jensen" authorContact="christiansorup@me.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e167-5c41-57e7-502b" name="Rohan" book="Kingdoms of Men" revision="3" battleScribeVersion="2.00" authorName="Christian Sørup Jensen" authorContact="christiansorup@me.com" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -83,7 +83,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="0547-80c5-6848-4c03" name="New InfoLink" hidden="false" targetId="9b10-514e-8b67-ec9c" type="profile">
+            <infoLink id="0547-80c5-6848-4c03" name="New InfoLink" hidden="false" targetId="ac25-2fd8-3d85-7866" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1672,7 +1672,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="5c35-f3b8-e178-5244" name="New InfoLink" hidden="false" targetId="87fd-4bfc-9df9-aa62" type="profile">
+            <infoLink id="5c35-f3b8-e178-5244" name="New InfoLink" hidden="false" targetId="ac25-2fd8-3d85-7866" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2457,7 +2457,7 @@ Additionally, an Expert Rider can pick up Light Object without having to dismoun
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="0419-a8ac-a59a-9275" name="New InfoLink" hidden="false" targetId="9998-89a4-9536-3a40" type="profile">
+            <infoLink id="0419-a8ac-a59a-9275" name="New InfoLink" hidden="false" targetId="b55b-5615-4438-2b70" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>

--- a/The_Fellowship.cat
+++ b/The_Fellowship.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90ff-6093-09d6-f3b3" name="The Fellowship" revision="1" battleScribeVersion="2.00" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90ff-6093-09d6-f3b3" name="The Fellowship" revision="2" battleScribeVersion="2.00" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -91,7 +91,7 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="06bd-97b6-9a2c-fa47" name="New InfoLink" hidden="false" targetId="0b1d-2177-4275-126d" type="profile">
+        <infoLink id="06bd-97b6-9a2c-fa47" name="New InfoLink" hidden="false" targetId="21b8-8e9e-6161-0812" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -422,7 +422,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="065a-fe5e-aa47-ab48" name="New InfoLink" hidden="false" targetId="0b1d-2177-4275-126d" type="profile">
+        <infoLink id="065a-fe5e-aa47-ab48" name="New InfoLink" hidden="false" targetId="21b8-8e9e-6161-0812" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -733,7 +733,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="ea83-ef38-ff3b-4f0a" name="New InfoLink" hidden="false" targetId="9998-89a4-9536-3a40" type="profile">
+            <infoLink id="ea83-ef38-ff3b-4f0a" name="New InfoLink" hidden="false" targetId="b55b-5615-4438-2b70" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -829,7 +829,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="5125-87a3-977f-43d2" name="Shield" book="The Free Peoples" page="44" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -856,7 +858,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="822f-373c-d31f-4cd5" name="Horn of Gondor" book="The Free Peoples" page="44" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -878,7 +882,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="f02d-0876-79b0-b2ac" name="Elven Cloak" book="The Free Peoples" page="44" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1001,7 +1007,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="fd51-8fb8-273a-4a15" name="Elven Cloak" book="The Free Peoples" page="44" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1051,7 +1059,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="9200-56b0-af41-ccdf" name="New InfoLink" hidden="false" targetId="9998-89a4-9536-3a40" type="profile">
+            <infoLink id="9200-56b0-af41-ccdf" name="New InfoLink" hidden="false" targetId="b55b-5615-4438-2b70" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1160,7 +1168,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="746a-ed02-e5ab-4680" name="Mithril Coat" book="The Free Peoples" page="45" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1294,7 +1304,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="719a-aade-1ba4-93ee" name="Two- handed axe" book="The Free Peoples" page="46" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1315,7 +1327,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="8dcf-6ad9-e221-c48a" name="Throwing axes" book="The Free Peoples" page="46" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1336,7 +1350,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="a87e-5a15-312c-d2a1" name="Elven Cloak" book="The Free Peoples" page="46" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1735,7 +1751,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>

--- a/The_White_Council.cat
+++ b/The_White_Council.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6eec-3151-8274-e5e6" name="The White Council" revision="1" battleScribeVersion="2.00" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6eec-3151-8274-e5e6" name="The White Council" revision="2" battleScribeVersion="2.00" gameSystemId="16cf-760b-7965-6537" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -91,7 +91,7 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="5473-cfd5-e437-846b" name="New InfoLink" hidden="false" targetId="0b1d-2177-4275-126d" type="profile">
+        <infoLink id="5473-cfd5-e437-846b" name="New InfoLink" hidden="false" targetId="21b8-8e9e-6161-0812" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -390,7 +390,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="11ae-472f-4239-6916" name="New InfoLink" hidden="false" targetId="0b1d-2177-4275-126d" type="profile">
+        <infoLink id="11ae-472f-4239-6916" name="New InfoLink" hidden="false" targetId="21b8-8e9e-6161-0812" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -523,7 +523,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="3171-126d-a05e-b904" name="Heavy Armour" book="The Free Peoples" page="18" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -537,7 +539,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -663,7 +667,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -811,7 +817,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="6b95-b19a-995c-6086" name="Heavy Armour" book="The Free Peoples" page="17" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -825,7 +833,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -980,7 +990,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -1119,7 +1131,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -1181,7 +1195,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="8e50-fbf4-f299-daf7" name="New InfoLink" hidden="false" targetId="9b10-514e-8b67-ec9c" type="profile">
+            <infoLink id="8e50-fbf4-f299-daf7" name="New InfoLink" hidden="false" targetId="ac25-2fd8-3d85-7866" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1350,7 +1364,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="1165-29ef-88f8-b5e9" name="Elf Bow" book="The Free Peoples" page="25" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1371,7 +1387,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="e379-12cb-08a2-277c" name="Elven blade" book="The Free Peoples" page="25" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1392,7 +1410,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="c2b9-1801-66a8-c0e0" name="Elven Cloak" book="The Free Peoples" page="25" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1413,7 +1433,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -1550,7 +1572,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="3cd9-4530-39b1-87d6" name="New InfoLink" hidden="false" targetId="9998-89a4-9536-3a40" type="profile">
+            <infoLink id="3cd9-4530-39b1-87d6" name="New InfoLink" hidden="false" targetId="b55b-5615-4438-2b70" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1712,7 +1734,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="08ca-3b26-9bfd-51ff" name="Horse" book="The Free Peoples" page="55" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1797,7 +1821,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="1ab3-be65-9bf1-af23" name="New InfoLink" hidden="false" targetId="0b1d-2177-4275-126d" type="profile">
+        <infoLink id="1ab3-be65-9bf1-af23" name="New InfoLink" hidden="false" targetId="21b8-8e9e-6161-0812" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1822,7 +1846,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="7e98-f7b4-f909-4ebf" name="Nenya" book="The Free Peoples" page="55" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1844,7 +1870,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -2012,7 +2040,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="a07f-a25e-af7f-abd8" name="Horse" book="The Free Peoples" page="56" hidden="false" collective="false" type="upgrade">
           <profiles/>


### PR DESCRIPTION
fixed missing links in catalogues: Arnor, Rohan, The Fiefdoms, The White Council, The Fellowship, Eregion and Rivendell, Lothlorien and Mirkwood, Numenor and Minas Tirith