### PR TITLE
Fixes and additions

### DIFF
--- a/Arnor.cat
+++ b/Arnor.cat
@@ -234,7 +234,9 @@ You may opt to take a Grey Company force. If you do so, your force (or an allied
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ef1-f91b-3e00-691d" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="21e5-9cea-e0e8-9ec1" name="Bow" book="Kingdoms of Men" page="37" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -326,7 +328,9 @@ You may opt to take a Grey Company force. If you do so, your force (or an allied
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="725d-1c14-e621-eabe" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="e536-8b5a-3c66-d760" name="Spear" book="Kingdoms of Men" page="38" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -819,7 +823,9 @@ To represent this, the surviving twin&apos;s Strength is increased to 5 and his 
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5825-2f87-24b1-83e2" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="c131-f3c1-2f66-1f41" name="Horse" book="Kingdoms of Men" page="39" hidden="false" collective="false" type="upgrade">
           <profiles/>

--- a/Durin's_Folk.cat
+++ b/Durin's_Folk.cat
@@ -33,7 +33,8 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0870-644e-a05d-b791" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0870-644e-a05d-b791" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d5e-ff98-22f5-b6aa" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="d4fe-dc1b-499f-823f" name="The Crown of Kings" book="The Free Peoples" page="31" hidden="false" collective="false" type="upgrade">
@@ -400,7 +401,8 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05e9-3821-134b-bfa7" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05e9-3821-134b-bfa7" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60d8-ffa7-009d-9e53" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="3223-ff34-2db3-844b" name="Torozûl" book="The Free Peoples" page="31" hidden="false" collective="false" type="upgrade">
@@ -468,7 +470,8 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7802-580c-ee5b-c358" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7802-580c-ee5b-c358" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b71-6e9d-27fb-43e4" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="405d-3d5a-ee22-c429" name="Durin&apos;s Axe" book="The Free People&apos;s" page="31" hidden="false" collective="false" type="upgrade">
@@ -573,7 +576,8 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1c8-2d34-85ac-9939" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1c8-2d34-85ac-9939" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51d4-ac4f-357a-a2aa" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="a324-689f-7f1b-0176" name="Barazántathûl" book="The Free Peoples" page="32" hidden="false" collective="false" type="upgrade">
@@ -649,7 +653,8 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c31-d7aa-30e0-0939" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c31-d7aa-30e0-0939" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f462-014f-dd29-f02e" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="b64d-9c7b-267b-43f8" name="Elven Cloak" book="The Free Peoples" page="32" hidden="false" collective="false" type="upgrade">
@@ -744,7 +749,8 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ad3-95ec-a013-2be8" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ad3-95ec-a013-2be8" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="093b-a533-e7dd-a6bc" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -813,7 +819,8 @@
       </infoLinks>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8737-8062-88f4-3f1c" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8737-8062-88f4-3f1c" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="250e-f557-2029-7b1d" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="2bb0-06e4-6cb6-775f" name="Kalazál" book="The Free Peoples" page="33" hidden="false" collective="false" type="upgrade">
@@ -1071,7 +1078,9 @@
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9251-3813-14a9-b890" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="e378-8720-deac-d452" name="Throwing Axes" book="The Free Peoples" page="34" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1166,7 +1175,7 @@
         <cost name="pts" costTypeId="points" value="60.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="22cf-e732-aed7-6815" name="Dwarf King" book="The Free Peoples" page="34" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="22cf-e732-aed7-6815" name="Dwarf King" book="The Free Peoples" page="34" hidden="false" collective="false" categoryEntryId="8e06-cb8f-41c0-09a4" type="upgrade">
       <profiles>
         <profile id="f7aa-af16-6714-bf52" name="Dwarf King" book="The Free Peoples" page="34" hidden="false" profileTypeId="07d0-bd3a-4a2e-7fc3" profileTypeName="Hero/Independent Hero">
           <profiles/>
@@ -1191,7 +1200,9 @@
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c42-0881-add2-2f4f" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="b278-ab4e-dab5-a2b9" name="Throwing Axes" book="The Free Peoples" page="34" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1298,7 +1309,9 @@
       </rules>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40bb-eb69-e7b9-f8bc" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
@@ -1380,7 +1393,9 @@
       </rules>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60c4-c4d9-3ab5-221d" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="33cf-a5c4-a58e-aca1" name="1 King&apos;s Champion and 2 Heralds" book="The Free Peoples" page="35" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1555,7 +1570,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -1575,7 +1592,9 @@
           <constraints/>
         </entryLink>
       </entryLinks>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="a4df-f76c-8e71-b8b6" name="Khazâd Guard" book="The Free Peoples" page="37" hidden="false" collective="false" categoryEntryId="e07a-883e-1b26-d891" type="model">
       <profiles>
@@ -1695,7 +1714,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="57d9-da33-4117-09f2" name="Dwarf Engineer Captain" book="The Free Peoples" page="37" hidden="false" collective="false" type="upgrade">
           <profiles/>

--- a/Eregion_and_Rivendell.cat
+++ b/Eregion_and_Rivendell.cat
@@ -1101,7 +1101,9 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78b1-6706-9e70-2f47" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="741a-94fa-53c5-2547" name="Horse" book="The Free Peoples" page="21" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1261,7 +1263,9 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0e7-6b59-e5cb-9aee" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>

--- a/Lothlórien_and_Mirkwood.cat
+++ b/Lothlórien_and_Mirkwood.cat
@@ -516,7 +516,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="8.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b884-7301-c60f-a8f8" name="Galadhrim Knight" book="The Free Peoples" page="27" hidden="false" collective="false" categoryEntryId="e07a-883e-1b26-d891" type="model">
@@ -739,7 +739,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="18.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4dc8-8f37-7f80-e417" name="Haldir" book="The Free Peoples" page="24" hidden="false" collective="false" categoryEntryId="8e06-cb8f-41c0-09a4" type="model">
@@ -1671,7 +1671,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="0e80-76fb-c583-1e61" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc72-5570-00d9-bbd4" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc72-5570-00d9-bbd4" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -1727,7 +1727,9 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="598a-fe20-dc56-74ba" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="007e-cbdb-41f7-76d7" name="Elf bow" book="The Free Peoples" page="26" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -1808,7 +1810,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="80.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f2ac-ded9-17de-f7c2" name="Galadhrim Stormcaller" book="The Free Peoples" page="26" hidden="false" collective="false" categoryEntryId="8e06-cb8f-41c0-09a4" type="model">
@@ -1888,7 +1890,9 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f188-4172-01db-75be" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
@@ -1948,7 +1952,9 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c82-e1eb-b100-3754" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="17df-94fc-78cc-6b7c" name="Armoured horse" book="The Free Peoples" page="26" hidden="false" collective="false" type="upgrade">
           <profiles/>

--- a/Minas_Tirith.cat
+++ b/Minas_Tirith.cat
@@ -619,6 +619,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d5b-85ca-384b-4a84" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="c80e-714d-11ed-aca5" name="Heavy armour" book="Kingdoms of Men" page="18" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
@@ -796,7 +797,9 @@
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f10b-9365-0064-4396" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="9616-adfa-db6f-076f" name="Heavy armour" book="Kingdoms of Men" page="20" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
@@ -1633,7 +1636,9 @@
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc6e-e2e9-17f1-bd74" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="7b7b-8b50-7b54-346f" name="Armour" book="Kingdoms of Men" page="20" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
@@ -1827,7 +1832,9 @@
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fccc-71f4-2018-82c4" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="f171-34c2-31f7-088c" name="Heavy armour" book="Kingdoms of Men" page="20" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>

--- a/Rohan.cat
+++ b/Rohan.cat
@@ -39,7 +39,9 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a958-8cee-1151-0944" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="2ae9-4292-668f-30dc" name="Armour" book="Kingdoms of Men" page="34" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>

--- a/The_Fiefdoms.cat
+++ b/The_Fiefdoms.cat
@@ -331,7 +331,9 @@
       </rules>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24be-c942-97d1-ed3d" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="bfb2-9bc5-3773-be75" name="Heavy armour" book="Kingdoms of Men" page="26" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>

--- a/The_Shire.cat
+++ b/The_Shire.cat
@@ -7,7 +7,7 @@
   <profileTypes/>
   <forceEntries/>
   <selectionEntries>
-    <selectionEntry id="be5c-a3f8-37e2-fce0" name="Frodo of the Nine Fingers" book="The Free Peoples" page="39" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+    <selectionEntry id="be5c-a3f8-37e2-fce0" name="Frodo of the Nine Fingers" book="The Free Peoples" page="39" hidden="false" collective="false" categoryEntryId="8e06-cb8f-41c0-09a4" type="model">
       <profiles>
         <profile id="67b0-f957-f8d7-d2b5" name="Frodo of the Nine Fingers" book="The Free Peoples" page="39" hidden="false" profileTypeId="07d0-bd3a-4a2e-7fc3" profileTypeName="Hero/Independent Hero">
           <profiles/>
@@ -83,7 +83,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="757a-76bb-612e-17d0" name="Elven Cloak" book="The Free Peoples" page="39" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -191,7 +193,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="83c2-94e5-e3b2-2f26" name="Elven Cloak" book="The Free Peoples" page="39" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -299,7 +303,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="6d7e-f0b9-dd42-e138" name="Elven Cloak" book="The Free Peoples" page="39" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -440,7 +446,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="dddb-584a-dcb1-01db" name="War Horn" book="The Free Peoples" page="41" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -556,7 +564,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="2924-365d-b0d8-146f" name="Horn of the Riddermark" book="The Free Peoples" page="40" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -578,7 +588,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="8302-2be6-2f14-8b78" name="Elven Cloak" book="The Free Peoples" page="40" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -921,7 +933,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -1041,7 +1055,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>


### PR DESCRIPTION
Fixed points for: Durin's Folk, Vault warden Team; Lothlorien and Mirkwood, Galadhrim warrior, Galadhrim Knight, Woodelf Captain
Fixed Category for The Shire, Frodo of the nine fingers
Added limitations to: All heroes of Durin's Folk catalogue; Eregion and Rivendell, High elf Captain, High elf Stormcaller; Lothlorien and Mirkwood, Galadhrim Captain; Rohan, Captain of Rohan; The Fiefdoms, Captain of Dol Amroth